### PR TITLE
testing upstream ci

### DIFF
--- a/aneris/harmonize.py
+++ b/aneris/harmonize.py
@@ -774,7 +774,8 @@ def diagnostics(unharmonized, model, metadata, config=None):
         report['{}_diff'.format(end)] = bigend
 
     report = report.drop(cols, axis=1).dropna(how='all')
-    report['method'] = metadata.loc[report.index, 'method']
+    idx = metadata.index.intersection(report.index)
+    report['method'] = metadata.loc[idx, 'method']
     report = report[~report['method'].isin(['model_zero', np.nan])]
 
     #


### PR DESCRIPTION
upstream CI has been broken likely due to a `pandas` version update with the below error. this is a PR to test if the [fix](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike) suggested by `pandas` works.

To note, these tests are only run if initiated from the upstream (this) repo, due to CI environment variable requirements.

CI history:

- d44ee5f0 was the last passing commit
- 7fbbf9f12 passed in mac, but not linux (with below error)
- a517292b failed in both, but due to `seaborn` dropping support of `tsplot` (fixed by @coroa in 834cb4a, in which mac now fails with the below error)

```
=================================== FAILURES ===================================
_______________ TestHarmonizeRegression.test_regression_ci[msg] ________________
self = <test_regression.TestHarmonizeRegression object at 0x7fbb8a995080>
name = 'msg'
    @pytest.mark.skipif(not ON_CI, reason=ON_CI_REASON)
    @pytest.mark.parametrize("name", ['msg', 'gcam'])
    def test_regression_ci(self, name):
        prefix = join(ci_path, 'test-{}'.format(name))
        checkf = '{}_harmonized.xlsx'.format(name)
        hist = 'history.csv'
        reg = 'regiondef.xlsx'
        rc = 'rc.yaml'
        inf = 'inputfile.xlsx'
    
        # copy needed files
        for fname in [hist, rc, checkf]:
            src = join(ci_path, fname)
            dst = join(prefix, fname)
            shutil.copyfile(src, dst)
    
        # get all arguments
>       self._run(inf, checkf, hist, reg, rc, prefix, name)
test_regression.py:112: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test_regression.py:64: in _run
    inf, hist, reg, rc, prefix, name, return_result=False,
../../../../miniconda/envs/testing/lib/python3.6/site-packages/aneris_iamc-0.2.0+3.g7fbbf9f-py3.6.egg/aneris/cli.py:65: in harmonize
    driver.harmonize(scenario)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/aneris_iamc-0.2.0+3.g7fbbf9f-py3.6.egg/aneris/harmonize.py:529: in harmonize
    unharmonized, self._model, self._meta, config=diagnostic_config)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/aneris_iamc-0.2.0+3.g7fbbf9f-py3.6.egg/aneris/harmonize.py:769: in diagnostics
    report['method'] = metadata.loc[report.index, 'method']
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1760: in __getitem__
    return self._getitem_tuple(key)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1270: in _getitem_tuple
    return self._getitem_lowerdim(tup)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1371: in _getitem_lowerdim
    return self._getitem_nested_tuple(tup)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1451: in _getitem_nested_tuple
    obj = getattr(obj, self.name)._getitem_axis(key, axis=axis)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1952: in _getitem_axis
    return self._getitem_iterable(key, axis=axis)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1593: in _getitem_iterable
    keyarr, indexer = self._get_listlike_indexer(key, axis, raise_missing=False)
../../../../miniconda/envs/testing/lib/python3.6/site-packages/pandas/core/indexing.py:1551: in _get_listlike_indexer
    keyarr, indexer, o._get_axis_number(axis), raise_missing=raise_missing
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <pandas.core.indexing._LocIndexer object at 0x7fbb8a8218b8>
key = MultiIndex([(  'AFR',    'BC', ...),
            (  'AFR',    'BC', ...),
            (  'AFR',    'BC', ...),
       ...  'SO2', ...),
            ('World',   'SO2', ...)],
           names=['region', 'gas', 'sector', 'units'], length=261)
indexer = array([  4,   6,   8,  20,  23,  27,  31,  33,  34,  35,  37,  40,  41,
        43,  44,  46,  49,  54,  56,  64,  66,...971, 972,  -1, 974,  -1, 975,  -1,
        -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1, 983,  -1,
        -1])
axis = 0, raise_missing = False
    def _validate_read_indexer(
        self, key, indexer, axis: int, raise_missing: bool = False
    ):
        """
        Check that indexer can be used to return a result.
    
        e.g. at least one element was found,
        unless the list of keys was actually empty.
    
        Parameters
        ----------
        key : list-like
            Targeted labels (only used to show correct error message).
        indexer: array-like of booleans
            Indices corresponding to the key,
            (with -1 indicating not found).
        axis: int
            Dimension on which the indexing is being made.
        raise_missing: bool
            Whether to raise a KeyError if some labels are not found. Will be
            removed in the future, and then this method will always behave as
            if raise_missing=True.
    
        Raises
        ------
        KeyError
            If at least one key was requested but none was found, and
            raise_missing=True.
        """
        ax = self.obj._get_axis(axis)
    
        if len(key) == 0:
            return
    
        # Count missing values:
        missing = (indexer < 0).sum()
    
        if missing:
            if missing == len(indexer):
                axis_name = self.obj._get_axis_name(axis)
                raise KeyError(f"None of [{key}] are in the [{axis_name}]")
    
            # We (temporarily) allow for some missing keys with .loc, except in
            # some cases (e.g. setting) in which "raise_missing" will be False
            if not (self.name == "loc" and not raise_missing):
                not_found = list(set(key) - set(ax))
                raise KeyError(f"{not_found} not in index")
    
            # we skip the warning on Categorical/Interval
            # as this check is actually done (check for
            # non-missing values), but a bit later in the
            # code, so we want to avoid warning & then
            # just raising
            if not (ax.is_categorical() or ax.is_interval()):
                raise KeyError(
>                   "Passing list-likes to .loc or [] with any missing labels "
                    "is no longer supported, see "
                    "https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"  # noqa:E501
                )
E               KeyError: 'Passing list-likes to .loc or [] with any missing labels is no longer supported, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike'
```