### PR TITLE
bump ci versions

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7]
+        python-version: [3.9]
 
     steps:
     - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - name: Checkout repository
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7]
+        python-version: [3.9]
         pandas-version: [1.1, 1.2, 1.2.5]
 
     steps:
@@ -175,7 +175,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7]
+        python-version: [3.9]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7]
+        python-version: [3.9]
         pandas-version: [1.1, 1.2, 1.2.5]
 
     steps:

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - name: Checkout repository
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.9]
+        python-version: [3.7]
         pandas-version: [1.1, 1.2, 1.2.5]
 
     steps:

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.9]
+        python-version: [3.8]
         pandas-version: [1.1, 1.2, 1.2.5]
 
     steps:

--- a/ci/environment-conda-default.yml
+++ b/ci/environment-conda-default.yml
@@ -1,9 +1,10 @@
 
 dependencies:
 - numpy
-- "pandas>=1.1"
+- pandas >=1.1
 - pyyaml
-- xlrd
+- xlrd >=2.0
+- openpyxl
 - xlsxwriter
 - matplotlib
 - seaborn

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ logo = r"""
 """
 
 REQUIREMENTS = [
-    'argparse',
     'numpy',
     'pandas>=1.1',
     'PyYAML',
-    'xlrd==1.2.0',
+    'xlrd>=2.0',
+    'openpyxl',
     'xlsxwriter',
     'matplotlib',
     'pyomo>=5'


### PR DESCRIPTION
FYI @coroa @jkikstra @znicholls 

I have updated CI to only run on py3.8 and 3.9. py3.7 was causing unknown core dump failures (impossible to debug from my end). 

regression tests run and pass, so all is fine from a reproducibility side IMO.

@coroa can you build against the changes in this PR so we can separate if there are CI issues related to your other updates in #43 