### PR TITLE
Add workflow to publish on pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: Cache Python packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: publish-${{ runner.os }}
+
+    - name: Upgrade pip, wheel, setuptools-scm
+      run: python -m pip install --upgrade pip wheel setuptools-scm twine
+
+    - name: Build package
+      run: |
+        python3 setup.py bdist_wheel sdist
+        twine check dist/*
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish
 
 on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
   release:
     types: [ published ]
 
@@ -28,8 +31,17 @@ jobs:
         python3 setup.py bdist_wheel sdist
         twine check dist/*
 
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      with:
+        user: __token__
+        password: ${{ secrets.TESTPYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@v1.4.1
+      if: github.event_name == 'release'
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -17,9 +17,8 @@ dependencies:
     - sphinx-gallery
     - nbsphinx
     - numpydoc
-    - cloud_sptheme
     - nbformat
     - ipython
     - jupyter
     - jupyter_contrib_nbextensions
-    - pillow  
+    - pillow

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - pip
   - pip:
     - sphinx
-    - sphinxcontrib-exceltable
     - sphinxcontrib-bibtex<2.0
     - sphinxcontrib-fulltoc
     - sphinxcontrib-programoutput

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,7 +39,6 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'cloud_sptheme.ext.table_styling',
     'numpydoc',
     'nbsphinx',
     'sphinxcontrib.bibtex',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -43,7 +43,6 @@ extensions = [
     'nbsphinx',
     'sphinxcontrib.bibtex',
     'sphinxcontrib.programoutput',
-    'sphinxcontrib.exceltable',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This PR adds the workflow for publishing on pypi (without an extra step for test.pypi.org), based on https://github.com/IAMconsortium/units/blob/main/.github/workflows/publish.yaml