### PR TITLE
Fix base_year_pattern method and check downscaling results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,61 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: check-merge-conflict
+  - id: end-of-file-fixer
+  #- id: fix-encoding-pragma # ruff does not thing this makes sense
+  - id: mixed-line-ending
+  - id: trailing-whitespace
+  - id: check-added-large-files
+    args: ["--maxkb=2000"]
+
+# # Convert relative imports to absolute imports
+# - repo: https://github.com/MarcoGorelli/absolufy-imports
+#   rev: v0.3.1
+#   hooks:
+#   - id: absolufy-imports
+
+# Find common spelling mistakes in comments and docstrings
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+  - id: codespell
+    args: ['--ignore-regex="(\b[A-Z]+\b)"', '--ignore-words-list=fom'] # Ignore capital case words, e.g. country codes
+    types_or: [python, rst, markdown]
+    files: ^(scripts|doc)/
+
+# Make docstrings PEP 257 compliant
+- repo: https://github.com/PyCQA/docformatter
+  rev: v1.5.1
+  hooks:
+  - id: docformatter
+    args: ["--in-place", "--make-summary-multi-line", "--pre-summary-newline"]
+
+- repo: https://github.com/keewis/blackdoc
+  rev: v0.3.8
+  hooks:
+  - id: blackdoc
+
+# Formatting with "black" coding style
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+      # Format Python files
+  - id: black
+      # Format Jupyter Python notebooks
+  - id: black-jupyter
+
+# Linting with ruff
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  # Ruff version.
+  rev: 'v0.0.245'
+  hooks:
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
+
+# # Check for FSFE REUSE compliance (licensing)
+# - repo: https://github.com/fsfe/reuse-tool
+#   rev: v1.1.2
+#   hooks:
+#   - id: reuse

--- a/src/aneris/downscaling/methods.py
+++ b/src/aneris/downscaling/methods.py
@@ -50,7 +50,7 @@ def base_year_pattern(
 
     weights = (
         semijoin(hist, context.regionmap_index, how="right")
-        .groupby(list(context.index) + [context.region_level], dropna=False)
+        .groupby(model.index.names, dropna=False)
         .transform(normalize)
     )
 


### PR DESCRIPTION
The default luc method base_year_pattern was normalizing only in respect to the specified index levels instead of the full model levels.

Adds also an optional check whether the downscaling results sum up to the regional totals.