### PR TITLE
Add functionality for dH_abs in methods choice

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
 
 # Formatting with "black" coding style
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 26.3.1
   hooks:
       # Format Python files
   - id: black

--- a/doc/source/make_logo.py
+++ b/doc/source/make_logo.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 plt.style.use("seaborn-deep")
 
 xmax = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ test = [
 ]
 units = ["openscm-units"]
 docs = [
-        "sphinx",
+        "sphinx<8",
         "sphinxcontrib-bibtex",
         "sphinxcontrib-programoutput",
         "sphinxcontrib-exceltable",
@@ -105,8 +105,6 @@ select = [
     # Pycodestyle
     "E",
     "W",
-    # isort
-    "I",
     # Pyupgrade
     "UP",
 ]

--- a/src/aneris/__init__.py
+++ b/src/aneris/__init__.py
@@ -5,7 +5,6 @@ from aneris.cmip6 import cmip6_utils, driver  # noqa: F401, F403
 from aneris.harmonize import *  # noqa: F401, F403
 from aneris.utils import *  # noqa: F401, F403
 
-
 try:
     __version__ = _version("aneris")
 except Exception:

--- a/src/aneris/_io.py
+++ b/src/aneris/_io.py
@@ -12,7 +12,6 @@ import yaml
 
 from aneris.utils import iamc_idx, isnum, isstr, pd_read
 
-
 RC_DEFAULTS = """
 config:
     default_luc_method: reduce_ratio_2150_cov

--- a/src/aneris/cmip6/cmip6_utils.py
+++ b/src/aneris/cmip6/cmip6_utils.py
@@ -13,7 +13,6 @@ from aneris.utils import (
     region_path,
 )
 
-
 # gases reported in kt of species
 kt_gases = [
     "N2O",

--- a/src/aneris/downscaling/core.py
+++ b/src/aneris/downscaling/core.py
@@ -16,7 +16,6 @@ from .methods import (
     simple_proxy,
 )
 
-
 DEFAULT_INDEX = ("sector", "gas")
 
 

--- a/src/aneris/downscaling/intensity_convergence.py
+++ b/src/aneris/downscaling/intensity_convergence.py
@@ -11,7 +11,6 @@ from scipy.optimize import root_scalar
 from ..utils import normalize, skipempty
 from .data import DownscalingContext
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/aneris/downscaling/methods.py
+++ b/src/aneris/downscaling/methods.py
@@ -9,7 +9,6 @@ from ..utils import normalize
 from .data import DownscalingContext
 from .intensity_convergence import intensity_convergence  # noqa: F401
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/aneris/grid.py
+++ b/src/aneris/grid.py
@@ -13,7 +13,6 @@ from pandas_indexing import isin
 
 from .utils import Pathy, logger
 
-
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -397,8 +397,8 @@ def default_method_choice(
     row,
     ratio_method="reduce_ratio_2080",
     offset_method="reduce_offset_2080",
-    luc_method="reduce_offset_2150_cov",
-    luc_cov_threshold=10,
+    luc_method="reduce_ratio_2150_cov",
+    luc_cov_threshold=20,
 ):
     """
     Default decision tree as documented at.
@@ -408,7 +408,7 @@ def default_method_choice(
     for arguments available in row and their definition
     """
     # special cases
-    if np.isclose(row.h, 0, atol=1e-3):
+    if np.isclose(row.h, 1e-6, atol=1e-3):
         return "hist_zero"
     if row.zero_m:
         return "model_zero"
@@ -437,8 +437,17 @@ def default_method_choice(
             # dH small?
             # Defined at the relative difference is less than 50% of historical data
             # or under the absolute threshold
-            if (row.dH < 0.5) or (row.dH_abs < row.dH_abs_thresh):
-                return ratio_method
+            if (row.dH.abs() < 0.5) or (row.dH_abs < row.dH_abs_thresh):
+                if row.dH < 0:
+                    # If dH is negative (model data > historical data)
+                    # Then we can use the ratio method
+                    # Applying a negative offset could return negative values
+                    return ratio_method
+                else:
+                    # If dH is positive (model data < historical data)
+                    # Then we use the offset method, as the ratio method can substantially
+                    # Increase the values and lead to strange pathways
+                    return offset_method
             else:
                 # goes negative?
                 if row.neg_m:
@@ -557,7 +566,7 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
     except KeyError:
         h = hist[y]
         m = model[y]
-    dH = (h - m).abs() / h
+    dH = (h - m) / h
     dH_abs = (h - m).abs()
     f = h / m
     dM = (model.max(axis=1) - model.min(axis=1)).abs() / model.max(axis=1)

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -397,8 +397,8 @@ def default_method_choice(
     row,
     ratio_method="reduce_ratio_2080",
     offset_method="reduce_offset_2080",
-    luc_method="reduce_ratio_2150_cov",
-    luc_cov_threshold=20,
+    luc_method="reduce_offset_2150_cov",
+    luc_cov_threshold=10,
 ):
     """
     Default decision tree as documented at.
@@ -406,6 +406,8 @@ def default_method_choice(
     Refer to choice flow chart at
     https://drive.google.com/drive/folders/0B6_Oqvcg8eP9QXVKX2lFVUJiZHc
     for arguments available in row and their definition
+
+    Neil Grant: Have made changes which would amend this flow-chart
     """
     # special cases
     if np.isclose(row.h, 1e-6, atol=1e-3):
@@ -437,17 +439,26 @@ def default_method_choice(
             # dH small?
             # Defined at the relative difference is less than 50% of historical data
             # or under the absolute threshold
-            if (abs(row.dH) < 0.5) or (row.dH_abs < row.dH_abs_thresh):
+            if row.dH_abs < row.dH_abs_thresh:
+                # If dH_abs is small, this suggests
+                # The data being harmonised is a small ~near zero component
                 if row.dH < 0:
                     # If dH is negative (model data > historical data)
                     # Then we can use the ratio method
                     # Applying a negative offset could return negative values
+                    # Which might not be always physically possible (outside of CO2)
                     return ratio_method
                 else:
                     # If dH is positive (model data < historical data)
                     # Then we use the offset method, as the ratio method can substantially
-                    # Increase the values and lead to strange pathways
+                    # Increase the values and lead to strange pathways, e.g. 
+                    # When the variable is small in historical data but growing rapidly (e.g. synfuels)
                     return offset_method
+            
+            # If dH_abs is large, this suggests that the component being harmonised is not ~near zero
+            # In this context we can just rely on the ratio method throughout
+            if abs(row.dH) < 0.5:
+                return ratio_method
             else:
                 # goes negative?
                 if row.neg_m:
@@ -500,11 +511,10 @@ def calc_dh_abs_threshold(df, model, base_year):
     select_ix.names = df.index.droplevel("parent_var").names
 
     for ix, sel_ix in zip(df.index, select_ix):
-        # In line with the relative threshold, the absolute threshold is set as
-        # Default as 50% of the parent variable in the model data
-
+        # Currently, the absolute threshold is set as 10% of the parent variable in the model data
+        # Under 10% is counted as "small"
         try:
-            df.loc[ix, "dH_abs_thresh"] = model.loc[sel_ix, base_year] * 0.5
+            df.loc[ix, "dH_abs_thresh"] = model.loc[sel_ix, base_year] * 0.1
         except:
             _log(
                 f"No data in the model dataframe for {sel_ix}, dH_abs_thresh not calculated"

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -7,10 +7,9 @@ from bisect import bisect
 
 import numpy as np
 import pandas as pd
-from pandas import IndexSlice as idx
 import pyomo.environ as pyo
+from pandas import IndexSlice as idx
 from pandas_indexing import assignlevel
-
 
 from aneris import utils
 

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -8,7 +8,6 @@ from bisect import bisect
 import numpy as np
 import pandas as pd
 import pyomo.environ as pyo
-from pandas import IndexSlice as idx
 from pandas_indexing import assignlevel
 
 from aneris import utils
@@ -502,7 +501,7 @@ def calc_dh_abs_threshold(df, model, base_year):
             ),
         )
     except:
-        _log(f"Dataframe has no attribute 'variable', dH abs cannot be calculated")
+        _log("Dataframe has no attribute 'variable', dH abs cannot be calculated")
         df.loc[:, "dH_abs_thresh"] = np.nan
 
         return df

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from pandas import IndexSlice as idx
 import pyomo.environ as pyo
-import pandas_indexing as pix
+from pandas_indexing import assignlevel
 
 
 from aneris import utils
@@ -475,7 +475,8 @@ def calc_dh_abs_threshold(df, model, base_year):
     # E.g. parent variable of FE|Industry|Liquids = FE|Industry
     # Or parent variable of Emissions|CO2|Demand|Industry = Emissions|CO2|Demand
     df = (
-        df.pix.assign(
+        assignlevel(
+            df,
             parent_var = df.variable.map(
                 lambda s: '|'.join(s.split('|')[:-1])
                 # if len(s.split('|')[:-1])>1 else s

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -426,6 +426,10 @@ def default_method_choice(
         else:
             return "constant_offset"
     else:
+        # variable going to zero (phase-out)? Always use ratio to avoid
+        # an offset driving values below zero as the variable approaches zero.
+        if np.isclose(row.variable_min, 0, atol=1e-6):
+            return ratio_method
         # is this co2?
         # ZN: This gas dependence isn't documented in the default
         # decision tree
@@ -441,18 +445,20 @@ def default_method_choice(
             if (abs(row.dH) > 0.5) & (row.dH_abs < row.dH_abs_thresh):
                 # If dH is large, but dH_abs is small, this suggests
                 # The data being harmonised is a small ~near zero component
-                # (under 20% of the parent variable)
-                if row.dH < 0:
-                    # If dH is negative (model data > historical data)
-                    # Then we can use the ratio method
-                    # Applying a negative offset could return negative values
-                    # Which might not be always physically possible (outside of CO2)
+                # (under 10% of the parent variable)
+                if row.dH < 0 and row.dH_abs > row.variable_min:
+                    # dH < 0: model > hist, so offset would be negative.
+                    # dH_abs > variable_min: the offset magnitude exceeds the
+                    # variable's minimum future value, so applying an offset
+                    # would push values below zero. Use ratio based method instead.
+                    # This also captures the "shrinking variable" case: if the
+                    # variable is growing, variable_min will be large and the
+                    # offset is safe, falling through to offset_method below.
                     return ratio_method
                 else:
-                    # If dH is positive (model data < historical data)
-                    # Then we use the offset method, as the ratio method can substantially
-                    # Increase the values and lead to strange pathways, e.g.
-                    # When the variable is small in historical data but growing rapidly (e.g. synfuels)
+                    # Either the offset is positive (model < hist), or the offset
+                    # is negative but small enough not to cause negative values
+                    # (variable is growing or large enough to absorb the offset).
                     return offset_method
 
             # If dH_abs is large, this suggests that the component being harmonised is not ~near zero
@@ -591,6 +597,8 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
     zero_m = (model == 0).all(axis=1)
     go_neg = ((model.min(axis=1) - h) < 0).any()
     cov = hist.apply(coeff_of_var, axis=1)
+    future_cols = [c for c in model.columns if int(c) >= int(base_year)]
+    variable_min = model[future_cols].min(axis=1)
 
     df = pd.DataFrame(
         {
@@ -605,6 +613,7 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
             "cov": cov,
             "h": h,
             "m": m,
+            "variable_min": variable_min,
         }
     ).join(model.index.to_frame())
 

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -500,7 +500,7 @@ def calc_dh_abs_threshold(df, hist, base_year):
                 # if len(s.split('|')[:-1])>1 else s
             ),
         )
-    except:
+    except Exception:
         _log("Dataframe has no attribute 'variable', dH abs cannot be calculated")
         df.loc[:, "dH_abs_thresh"] = np.nan
 
@@ -516,7 +516,7 @@ def calc_dh_abs_threshold(df, hist, base_year):
         # also be in need of harmonisation.
         try:
             df.loc[ix, "dH_abs_thresh"] = hist.loc[sel_ix, base_year] * 0.1
-        except:
+        except Exception:
             _log(
                 f"No data in the model dataframe for {sel_ix}, dH_abs_thresh not calculated"
             )

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -437,7 +437,7 @@ def default_method_choice(
             # dH small?
             # Defined at the relative difference is less than 50% of historical data
             # or under the absolute threshold
-            if (row.dH.abs() < 0.5) or (row.dH_abs < row.dH_abs_thresh):
+            if (abs(row.dH) < 0.5) or (row.dH_abs < row.dH_abs_thresh):
                 if row.dH < 0:
                     # If dH is negative (model data > historical data)
                     # Then we can use the ratio method

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -14,8 +14,10 @@ from pandas_indexing import assignlevel
 
 from aneris import utils
 
+
 def _log(msg, *args, **kwargs):
     utils.logger().info(msg, *args, **kwargs)
+
 
 def harmonize_factors(df, hist, harmonize_year=2015):
     """
@@ -339,10 +341,7 @@ def budget(df, df_hist, harmonize_year=2015):
 
         assert (results.solver.status == pyo.SolverStatus.ok) and (
             results.solver.termination_condition == pyo.TerminationCondition.optimal
-        ), (
-            f"ipopt terminated budget optimization with status: "
-            f"{results.solver.status}, {results.solver.termination_condition}"
-        )
+        ), f"ipopt terminated budget optimization with status: {results.solver.status}, {results.solver.termination_condition}"
 
         harmonized.append([pyo.value(model.x[y]) for y in years])
 
@@ -410,7 +409,7 @@ def default_method_choice(
     for arguments available in row and their definition
     """
     # special cases
-    if np.isclose(row.h, 0, atol=1e-3): 
+    if np.isclose(row.h, 0, atol=1e-3):
         return "hist_zero"
     if row.zero_m:
         return "model_zero"
@@ -462,46 +461,46 @@ def calc_dh_abs_threshold(df, model, base_year):
     base_year : string, int
         harmonization year
 
-    
+
     Returns
     -------
     df : pd.DataFrame
        Modified dataframe with the dH_abs_threshold added
 
     """
-     #Calculate the dH_abs_threshold (for use in methods choice)
+    # Calculate the dH_abs_threshold (for use in methods choice)
 
     # Find parent variable, which is defined as the next level up in the hiearchy.
     # E.g. parent variable of FE|Industry|Liquids = FE|Industry
     # Or parent variable of Emissions|CO2|Demand|Industry = Emissions|CO2|Demand
-    df = (
-        assignlevel(
-            df,
-            parent_var = df.variable.map(
-                lambda s: '|'.join(s.split('|')[:-1])
-                # if len(s.split('|')[:-1])>1 else s
-                )
-                )
-        )
+    df = assignlevel(
+        df,
+        parent_var=df.variable.map(
+            lambda s: "|".join(s.split("|")[:-1])
+            # if len(s.split('|')[:-1])>1 else s
+        ),
+    )
 
     for ix in df.index[:]:
 
-        #Find the index with the same model/scenario/region/unit, 
-        #But looking for the parent variable
-        sel_slice = idx[ix[0],ix[1],ix[2],ix[5],ix[4]] 
+        # Find the index with the same model/scenario/region/unit,
+        # But looking for the parent variable
+        sel_slice = idx[ix[0], ix[1], ix[2], ix[5], ix[4]]
 
         # In line with the relative threshold, the absolute threshold is set as
         # Default as 50% of the parent variable in the model data
 
         try:
-            df.loc[ix,'dH_abs_thresh'] = model.loc[sel_slice,base_year] *0.5
+            df.loc[ix, "dH_abs_thresh"] = model.loc[sel_slice, base_year] * 0.5
         except:
-            _log(f"No data in the model dataframe for {sel_slice}, dH_abs_thresh not calculated")
-            df.loc[ix,'dH_abs_thresh'] = np.nan
+            _log(
+                f"No data in the model dataframe for {sel_slice}, dH_abs_thresh not calculated"
+            )
+            df.loc[ix, "dH_abs_thresh"] = np.nan
 
-    df = df.droplevel('parent_var')
+    df = df.droplevel("parent_var")
 
-    return(df)
+    return df
 
 
 def default_methods(hist, model, base_year, method_choice=None, **kwargs):
@@ -585,7 +584,7 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
         }
     ).join(model.index.to_frame())
 
-    df = calc_dh_abs_threshold(df,model,base_year)
+    df = calc_dh_abs_threshold(df, model, base_year)
 
     if method_choice is None:
         method_choice = default_method_choice

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -481,28 +481,33 @@ def calc_dh_abs_threshold(df, model, base_year):
     # Find parent variable, which is defined as the next level up in the hiearchy.
     # E.g. parent variable of FE|Industry|Liquids = FE|Industry
     # Or parent variable of Emissions|CO2|Demand|Industry = Emissions|CO2|Demand
-    df = assignlevel(
-        df,
-        parent_var=df.variable.map(
-            lambda s: "|".join(s.split("|")[:-1])
-            # if len(s.split('|')[:-1])>1 else s
-        ),
-    )
+    try:
+        df = assignlevel(
+            df,
+            parent_var=df.variable.map(
+                lambda s: "|".join(s.split("|")[:-1])
+                # if len(s.split('|')[:-1])>1 else s
+            ),
+        )
+    except:
+        _log(f"Dataframe has no attribute 'variable', dH abs cannot be calculated")
+        df.loc[:, "dH_abs_thresh"] = np.nan
 
-    for ix in df.index[:]:
+        return df
 
-        # Find the index with the same model/scenario/region/unit,
-        # But looking for the parent variable
-        sel_slice = idx[ix[0], ix[1], ix[2], ix[5], ix[4]]
+    # Find the index with the same indices, but switch the parent_variable in for the variable
+    select_ix = df.index.swaplevel("variable", "parent_var").droplevel("variable")
+    select_ix.names = df.index.droplevel("parent_var").names
 
+    for ix, sel_ix in zip(df.index, select_ix):
         # In line with the relative threshold, the absolute threshold is set as
         # Default as 50% of the parent variable in the model data
 
         try:
-            df.loc[ix, "dH_abs_thresh"] = model.loc[sel_slice, base_year] * 0.5
+            df.loc[ix, "dH_abs_thresh"] = model.loc[sel_ix, base_year] * 0.5
         except:
             _log(
-                f"No data in the model dataframe for {sel_slice}, dH_abs_thresh not calculated"
+                f"No data in the model dataframe for {sel_ix}, dH_abs_thresh not calculated"
             )
             df.loc[ix, "dH_abs_thresh"] = np.nan
 

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -7,10 +7,15 @@ from bisect import bisect
 
 import numpy as np
 import pandas as pd
+from pandas import IndexSlice as idx
 import pyomo.environ as pyo
+import pandas_indexing as pix
+
 
 from aneris import utils
 
+def _log(msg, *args, **kwargs):
+    utils.logger().info(msg, *args, **kwargs)
 
 def harmonize_factors(df, hist, harmonize_year=2015):
     """
@@ -405,7 +410,7 @@ def default_method_choice(
     for arguments available in row and their definition
     """
     # special cases
-    if row.h == 0:
+    if np.isclose(row.h, 0, atol=1e-3): 
         return "hist_zero"
     if row.zero_m:
         return "model_zero"
@@ -432,7 +437,9 @@ def default_method_choice(
             return luc_method
         else:
             # dH small?
-            if row.dH < 0.5:
+            # Defined at the relative difference is less than 50% of historical data
+            # or under the absolute threshold
+            if (row.dH < 0.5) or (row.dH_abs < row.dH_abs_thresh):
                 return ratio_method
             else:
                 # goes negative?
@@ -440,6 +447,60 @@ def default_method_choice(
                     return "reduce_ratio_2100"
                 else:
                     return "constant_ratio"
+
+
+def calc_dh_abs_threshold(df, model, base_year):
+    """
+    Calculates a value of dH_abs_threshold, which is a threshold used to help determine methods choice
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame produced by default_methods function
+    model : pd.DataFrame
+        model data
+    base_year : string, int
+        harmonization year
+
+    
+    Returns
+    -------
+    df : pd.DataFrame
+       Modified dataframe with the dH_abs_threshold added
+
+    """
+     #Calculate the dH_abs_threshold (for use in methods choice)
+
+    # Find parent variable, which is defined as the next level up in the hiearchy.
+    # E.g. parent variable of FE|Industry|Liquids = FE|Industry
+    # Or parent variable of Emissions|CO2|Demand|Industry = Emissions|CO2|Demand
+    df = (
+        df.pix.assign(
+            parent_var = df.variable.map(
+                lambda s: '|'.join(s.split('|')[:-1])
+                # if len(s.split('|')[:-1])>1 else s
+                )
+                )
+        )
+
+    for ix in df.index[:]:
+
+        #Find the index with the same model/scenario/region/unit, 
+        #But looking for the parent variable
+        sel_slice = idx[ix[0],ix[1],ix[2],ix[5],ix[4]] 
+
+        # In line with the relative threshold, the absolute threshold is set as
+        # Default as 50% of the parent variable in the model data
+
+        try:
+            df.loc[ix,'dH_abs_thresh'] = model.loc[sel_slice,base_year] *0.5
+        except:
+            _log(f"No data in the model dataframe for {sel_slice}, dH_abs_thresh not calculated")
+            df.loc[ix,'dH_abs_thresh'] = np.nan
+
+    df = df.droplevel('parent_var')
+
+    return(df)
 
 
 def default_methods(hist, model, base_year, method_choice=None, **kwargs):
@@ -498,6 +559,7 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
         h = hist[y]
         m = model[y]
     dH = (h - m).abs() / h
+    dH_abs = (h - m).abs()
     f = h / m
     dM = (model.max(axis=1) - model.min(axis=1)).abs() / model.max(axis=1)
     neg_m = (model < 0).any(axis=1)
@@ -509,6 +571,7 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
     df = pd.DataFrame(
         {
             "dH": dH,
+            "dH_abs": dH_abs,
             "f": f,
             "dM": dM,
             "neg_m": neg_m,
@@ -520,6 +583,8 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
             "m": m,
         }
     ).join(model.index.to_frame())
+
+    df = calc_dh_abs_threshold(df,model,base_year)
 
     if method_choice is None:
         method_choice = default_method_choice

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -441,7 +441,7 @@ def default_method_choice(
             # or under the absolute threshold
             if (abs(row.dH) > 0.5) & (row.dH_abs < row.dH_abs_thresh):
                 # If dH is large, but dH_abs is small, this suggests
-                # The data being harmonised is a small ~near zero component 
+                # The data being harmonised is a small ~near zero component
                 # (under 20% of the parent variable)
                 if row.dH < 0:
                     # If dH is negative (model data > historical data)
@@ -452,10 +452,10 @@ def default_method_choice(
                 else:
                     # If dH is positive (model data < historical data)
                     # Then we use the offset method, as the ratio method can substantially
-                    # Increase the values and lead to strange pathways, e.g. 
+                    # Increase the values and lead to strange pathways, e.g.
                     # When the variable is small in historical data but growing rapidly (e.g. synfuels)
                     return offset_method
-            
+
             # If dH_abs is large, this suggests that the component being harmonised is not ~near zero
             # In this context we can just rely on the ratio method throughout
             elif abs(row.dH) < 0.5:

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -467,7 +467,7 @@ def default_method_choice(
                     return "constant_ratio"
 
 
-def calc_dh_abs_threshold(df, model, base_year):
+def calc_dh_abs_threshold(df, hist, base_year):
     """
     Calculates a value of dH_abs_threshold, which is a threshold used to help determine methods choice
 
@@ -475,8 +475,8 @@ def calc_dh_abs_threshold(df, model, base_year):
     ----------
     df : pd.DataFrame
         DataFrame produced by default_methods function
-    model : pd.DataFrame
-        model data
+    hist : pd.DataFrame
+        Historical data
     base_year : string, int
         harmonization year
 
@@ -511,10 +511,11 @@ def calc_dh_abs_threshold(df, model, base_year):
     select_ix.names = df.index.droplevel("parent_var").names
 
     for ix, sel_ix in zip(df.index, select_ix):
-        # Currently, the absolute threshold is set as 10% of the parent variable in the model data
-        # Under 10% is counted as "small"
+        # Currently, the absolute threshold is set as 10% of the parent variable in the historical data
+        # Under 10% is counted as "small". We don't use model data here, as the model data could
+        # also be in need of harmonisation.
         try:
-            df.loc[ix, "dH_abs_thresh"] = model.loc[sel_ix, base_year] * 0.1
+            df.loc[ix, "dH_abs_thresh"] = hist.loc[sel_ix, base_year] * 0.1
         except:
             _log(
                 f"No data in the model dataframe for {sel_ix}, dH_abs_thresh not calculated"
@@ -607,7 +608,7 @@ def default_methods(hist, model, base_year, method_choice=None, **kwargs):
         }
     ).join(model.index.to_frame())
 
-    df = calc_dh_abs_threshold(df, model, base_year)
+    df = calc_dh_abs_threshold(df, hist, base_year)
 
     if method_choice is None:
         method_choice = default_method_choice

--- a/src/aneris/methods.py
+++ b/src/aneris/methods.py
@@ -439,9 +439,10 @@ def default_method_choice(
             # dH small?
             # Defined at the relative difference is less than 50% of historical data
             # or under the absolute threshold
-            if row.dH_abs < row.dH_abs_thresh:
-                # If dH_abs is small, this suggests
-                # The data being harmonised is a small ~near zero component
+            if (abs(row.dH) > 0.5) & (row.dH_abs < row.dH_abs_thresh):
+                # If dH is large, but dH_abs is small, this suggests
+                # The data being harmonised is a small ~near zero component 
+                # (under 20% of the parent variable)
                 if row.dH < 0:
                     # If dH is negative (model data > historical data)
                     # Then we can use the ratio method
@@ -457,7 +458,7 @@ def default_method_choice(
             
             # If dH_abs is large, this suggests that the component being harmonised is not ~near zero
             # In this context we can just rely on the ratio method throughout
-            if abs(row.dH) < 0.5:
+            elif abs(row.dH) < 0.5:
                 return ratio_method
             else:
                 # goes negative?

--- a/src/aneris/tutorial.py
+++ b/src/aneris/tutorial.py
@@ -1,13 +1,11 @@
 import os
 
-
 try:
     from urllib.request import urlretrieve  # py3
 except ImportError:
     from urllib import urlretrieve  # py2
 
 import aneris
-
 
 _default_cache_dir = os.path.join("~", ".aneris_tutorial_data")
 

--- a/src/aneris/utils.py
+++ b/src/aneris/utils.py
@@ -6,7 +6,6 @@ from typing import TypeAlias
 import pandas as pd
 import pycountry
 
-
 Pathy: TypeAlias = str | Path
 
 _logger = None

--- a/tests/ci/download_data.py
+++ b/tests/ci/download_data.py
@@ -3,7 +3,6 @@ import tarfile
 
 import requests
 
-
 username = os.environ["ANERIS_CI_USER"]
 password = os.environ["ANERIS_CI_PW"]
 

--- a/tests/test_convenience.py
+++ b/tests/test_convenience.py
@@ -627,7 +627,7 @@ def test_defaults(hist_df, scenarios_df):
             [
                 {"variable": "Emissions|CO2", "method": "reduce_ratio_2080"},
                 {"variable": "Emissions|CH4", "method": "reduce_ratio_2080"},
-                {"variable": "Emissions|CO2|AFOLU", "method": "reduce_ratio_2100"},
+                {"variable": "Emissions|CO2|AFOLU", "method": "reduce_offset_2080"},
                 {"variable": "Emissions|BC|AFOLU", "method": "constant_ratio"},
             ]
         ),

--- a/tests/test_convenience.py
+++ b/tests/test_convenience.py
@@ -13,7 +13,6 @@ from aneris.errors import (
     MissingHistoricalError,
 )
 
-
 pytest.importorskip("pint")
 import pint.errors
 

--- a/tests/test_default_decision_tree.py
+++ b/tests/test_default_decision_tree.py
@@ -163,7 +163,7 @@ def test_branch7(index_two_var):
     print(diags)
 
     exp = pd.Series(
-        ["reduce_ratio_2080", "reduce_ratio_2080"], index_two_var, name="methods"
+        ["reduce_offset_2080", "reduce_ratio_2080"], index_two_var, name="methods"
     )
     pdt.assert_series_equal(exp, obs, check_names=False)
 

--- a/tests/test_default_decision_tree.py
+++ b/tests/test_default_decision_tree.py
@@ -22,6 +22,20 @@ def index1_co2():
     return make_index(1, gas="CO2")
 
 
+@pytest.fixture
+def index_two_var():
+    return pd.MultiIndex.from_product(
+        [
+            ["region"],
+            [
+                "Emissions|CO2|Energy|Supply|Transportation",
+                "Emissions|CO2|Energy|Supply",
+            ],
+        ],
+        names=["region", "variable"],
+    )
+
+
 def test_hist_zero(index1):
     hist = pd.DataFrame({"2015": [0]}, index1)
     df = pd.DataFrame({"2015": [1.0]}, index1)
@@ -123,6 +137,62 @@ def test_branch6(index1):
     print(diags)
 
     exp = pd.Series(["reduce_offset_2150_cov"], index1, name="methods")
+    pdt.assert_series_equal(exp, obs, check_names=False)
+
+
+def test_branch7(index_two_var):
+    hist = pd.DataFrame(
+        {
+            "2000": [1.0, 20.0],
+            "2005": [2.0, 40.0],
+            "2010": [3.0, 50.0],
+            "2015": [2.0, 50.0],
+        },
+        index_two_var,
+    )
+
+    df = pd.DataFrame(
+        {
+            "2015": [3.5, 45.0],
+            "2020": [5.0, 60.0],
+        },
+        index_two_var,
+    )
+
+    obs, diags = harmonize.default_methods(hist, df, "2015")
+    print(diags)
+
+    exp = pd.Series(
+        ["reduce_ratio_2080", "reduce_ratio_2080"], index_two_var, name="methods"
+    )
+    pdt.assert_series_equal(exp, obs, check_names=False)
+
+
+def test_branch8(index_two_var):
+    hist = pd.DataFrame(
+        {
+            "2000": [1.0, 20.0],
+            "2005": [2.0, 40.0],
+            "2010": [3.0, 50.0],
+            "2015": [2.0, 50.0],
+        },
+        index_two_var,
+    )
+
+    df = pd.DataFrame(
+        {
+            "2015": [0.2, 30.0],
+            "2020": [0.1, 20.0],
+        },
+        index_two_var,
+    )
+
+    obs, diags = harmonize.default_methods(hist, df, "2015")
+    print(diags)
+
+    exp = pd.Series(
+        ["reduce_offset_2080", "reduce_ratio_2080"], index_two_var, name="methods"
+    )
     pdt.assert_series_equal(exp, obs, check_names=False)
 
 

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -5,7 +5,6 @@ import pytest
 
 from aneris import harmonize, utils
 
-
 nvals = 6
 
 
@@ -232,10 +231,10 @@ def test_harmonize_mix():
     npt.assert_array_almost_equal(obs, exp)
 
     # future year
-    obs = res["2060"][:2]
+    obs = res["2060"].iloc[:2]
     exp = [
-        _df["2060"][0] + (_hist["2015"][0] - _df["2015"][0]),
-        _df["2060"][1] * (_hist["2015"][1] / _df["2015"][1]),
+        _df["2060"].iloc[0] + (_hist["2015"].iloc[0] - _df["2015"].iloc[0]),
+        _df["2060"].iloc[1] * (_hist["2015"].iloc[1] / _df["2015"].iloc[1]),
     ]
     npt.assert_array_almost_equal(obs, exp)
 

--- a/tests/test_harmonize.py
+++ b/tests/test_harmonize.py
@@ -271,16 +271,19 @@ def test_harmonize_linear_interpolation():
 @pytest.mark.ipopt
 def test_harmonize_budget():
     df = _df.copy()
+    df.columns = df.columns.astype(int)
     hist = _hist.copy()
+    hist.columns = hist.columns.astype(int)
+
     methods = _methods.copy()
 
     h = harmonize.Harmonizer(df, hist)
     methods["method"] = "budget"
-    res = h.harmonize(year="2015", overrides=methods["method"])
+    res = h.harmonize(year=2015, overrides=methods["method"])
 
     # base year
-    obs = res["2015"]
-    exp = _hist["2015"]
+    obs = res[2015]
+    exp = hist[2015]
     npt.assert_array_almost_equal(obs, exp)
 
     # carbon budget conserved
@@ -295,5 +298,5 @@ def test_harmonize_budget():
 
     npt.assert_array_almost_equal(
         _carbon_budget(res),
-        _carbon_budget(df) - _carbon_budget(hist.loc[:, "2010":"2015"]),
+        _carbon_budget(df) - _carbon_budget(hist.loc[:, 2010:2015]),
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,6 @@ import pytest
 
 from aneris import _io
 
-
 _defaults = {
     "config": {
         "default_luc_method": "reduce_ratio_2150_cov",

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,7 +8,6 @@ from pandas.testing import assert_frame_equal
 
 from aneris import cli
 
-
 # This is a class that runs all tests through the harmonize CLI Note that it
 # uses the actual harmonize API rather than subprocessing the CLI because
 # coveralls does not pick up the lines covered in CLI calls when in a docker


### PR DESCRIPTION
This adds an option to determine methods choice not based on dH (a relative measure of the difference between historical and modelled data), but on dH_abs, an absolute measure.

This is useful in cases where the component being harmonised is a small variable (e.g. harmonising bio-liquids demand in industry, or a minor sub-species of gas). Here dH can be large, but dH_abs is still small, and hence the 'difference' between modelled and historic can still be seen as small enough to enforce convergence. 

Otherwise a `constant_ratio` approach can be enforced, even though dH_abs is small.

Code assesses what counts as a "small" absolute value by looking at the parent variable (which is the next level up in the IAMC hierarchy in this variable, e.g. Final Energy|Industry|Gases parent variable is Final Energy|Industry). dH_abs variables which are under half of the parent variable values are seen as small enough to still enforce convergence.